### PR TITLE
Rename package to PackageAnalyzer

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,4 +1,4 @@
-name = "AnalyzeRegistry"
+name = "PackageAnalyzer"
 uuid = "e713c705-17e4-4cec-abe0-95bf5bf3e10c"
 authors = ["Mosè Giordano <mose@gnu.org>"]
 version = "0.1.0"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,20 +1,20 @@
-using Documenter, AnalyzeRegistry
+using Documenter, PackageAnalyzer
 
-DocMeta.setdocmeta!(AnalyzeRegistry, :DocTestSetup, :(using AnalyzeRegistry); recursive=true)
+DocMeta.setdocmeta!(PackageAnalyzer, :DocTestSetup, :(using PackageAnalyzer); recursive=true)
 
 makedocs(
     format = Documenter.HTML(
         prettyurls = true
     ),
-    modules = [AnalyzeRegistry],
-    sitename = "AnalyzeRegistry.jl",
+    modules = [PackageAnalyzer],
+    sitename = "PackageAnalyzer.jl",
     pages = ["Home" => "index.md",
              "API Reference" => "api.md",
              "Saving results" => "serialization.md"]
 )
 
 deploydocs(
-    repo = "github.com/giordano/AnalyzeRegistry.jl.git",
+    repo = "github.com/giordano/PackageAnalyzer.jl.git",
     push_preview=true,
     devbranch = "main",
 )

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,5 +1,5 @@
 ## API reference
 
 ```@autodocs
-Modules = [AnalyzeRegistry]
+Modules = [PackageAnalyzer]
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,9 +1,9 @@
-# AnalyzeRegistry.jl
+# PackageAnalyzer.jl
 
 The main functionality of the package is the [`analyze`](@ref) function:
 
 ```julia
-julia> using AnalyzeRegistry
+julia> using PackageAnalyzer
 
 julia> analyze("Flux")
 Package Flux:
@@ -58,10 +58,10 @@ Package JuMP:
 Additionally, you can pass in the module itself:
 
 ```julia
-julia> using AnalyzeRegistry
+julia> using PackageAnalyzer
 
-julia> analyze(AnalyzeRegistry)
-Package AnalyzeRegistry:
+julia> analyze(PackageAnalyzer)
+Package PackageAnalyzer:
   * repo:
   * uuid: e713c705-17e4-4cec-abe0-95bf5bf3e10c
   * is reachable: true
@@ -83,7 +83,7 @@ You can also directly analyze the source code of a package via [`analyze`](@ref)
 by passing in the path to it, for example with the `pkgdir` function:
 
 ```julia
-julia> using AnalyzeRegistry, DataFrames
+julia> using PackageAnalyzer, DataFrames
 
 julia> analyze(pkgdir(DataFrames))
 Package DataFrames:
@@ -145,12 +145,12 @@ registry:
 
 ```julia
 julia> find_packages(; registry=general_registry())
-4632-element Vector{AnalyzeRegistry.RegistryEntry}:
- AnalyzeRegistry.RegistryEntry("/Users/eph/.julia/registries/General/C/CitableImage")
- AnalyzeRegistry.RegistryEntry("/Users/eph/.julia/registries/General/T/Trixi2Img")
- AnalyzeRegistry.RegistryEntry("/Users/eph/.julia/registries/General/I/ImPlot")
- AnalyzeRegistry.RegistryEntry("/Users/eph/.julia/registries/General/S/StableDQMC")
- AnalyzeRegistry.RegistryEntry("/Users/eph/.julia/registries/General/S/Strapping")
+4632-element Vector{PackageAnalyzer.RegistryEntry}:
+ PackageAnalyzer.RegistryEntry("/Users/eph/.julia/registries/General/C/CitableImage")
+ PackageAnalyzer.RegistryEntry("/Users/eph/.julia/registries/General/T/Trixi2Img")
+ PackageAnalyzer.RegistryEntry("/Users/eph/.julia/registries/General/I/ImPlot")
+ PackageAnalyzer.RegistryEntry("/Users/eph/.julia/registries/General/S/StableDQMC")
+ PackageAnalyzer.RegistryEntry("/Users/eph/.julia/registries/General/S/Strapping")
 [...]
 ```
 Do not abuse this function! Consider using the in-place function `analyze!(root, registry_entries)` to avoid re-cloning packages if you might run the analysis more than once.
@@ -165,7 +165,7 @@ containing much more detailed information about any or all files containing
 licenses, identified by [`licensecheck`](https://github.com/google/licensecheck) via [LicenseCheck.jl](https://github.com/ericphanson/LicenseCheck.jl). For example, [RandomProjectionTree.jl](https://github.com/jean-pierreBoth/RandomProjectionTree.jl) is dual licensed under both Apache-2.0 and the MIT license, and provides two separate license files. Interestingly, the README is also identified as containing an Apache-2.0 license; I've filed an [issue](https://github.com/google/licensecheck/issues/40) to see if this is intentional.
 
 ```julia
-julia> using AnalyzeRegistry, DataFrames
+julia> using PackageAnalyzer, DataFrames
 
 julia> result = analyze("RandomProjectionTree");
 
@@ -188,7 +188,7 @@ containing much more detailed information about the lines of code count
 (thanks to `tokei`) and can e.g. be passed to a `DataFrame` for further analysis.
 
 ```julia
-julia> using AnalyzeRegistry, DataFrames
+julia> using PackageAnalyzer, DataFrames
 
 julia> result = analyze(pkgdir(DataFrames));
 
@@ -221,7 +221,7 @@ usernames of the contributors, and the values are the corresponding numbers of
 contributions in that repository.
 
 ```julia
-julia> using AnalyzeRegistry, DataFrames
+julia> using PackageAnalyzer, DataFrames
 
 julia> result = analyze("DataFrames");
 
@@ -261,5 +261,5 @@ you can obtain some extra information about packages whose repository is hosted
 on GitHub (e.g. the list of contributors).  If you store the token as an
 environment variable called `GITHUB_TOKEN` or `GITHUB_AUTH`, this will be
 automatically used whenever possible, otherwise you can generate a GitHub
-authentication with the [`AnalyzeRegistry.github_auth`](@ref) function and pass
+authentication with the [`PackageAnalyzer.github_auth`](@ref) function and pass
 it to the functions accepting the `auth::GitHub.Authorization` keyword argument.

--- a/docs/src/serialization.md
+++ b/docs/src/serialization.md
@@ -1,10 +1,10 @@
 ## Saving results
 
-In just four lines of code, we can setup serialization of collections of AnalyzeRegistry's `Package` object to Apache arrow tables:
+In just four lines of code, we can setup serialization of collections of PackageAnalyzer's `Package` object to Apache arrow tables:
 
 ```@repl 1
-using Arrow, AnalyzeRegistry
-Arrow.ArrowTypes.registertype!(AnalyzeRegistry.Package, AnalyzeRegistry.Package)
+using Arrow, PackageAnalyzer
+Arrow.ArrowTypes.registertype!(PackageAnalyzer.Package, PackageAnalyzer.Package)
 save(path, packages) = Arrow.write(path, (; packages))
 load(path) = copy(Arrow.Table(path).packages)
 ```
@@ -18,4 +18,4 @@ roundtripped_results = load("packages.arrow")
 rm("packages.arrow") # hide
 ```
 
-Note that even if future versions of AnalyzeRegistry change the layout of `Package`'s and you forget the version used to serialize the results, you can use the same `load` function *without* calling `registertype!` in the Julia session in order to deserialize the results back as `NamedTuple`'s (instead of as `Package`s), providing some amount of robustness.
+Note that even if future versions of PackageAnalyzer change the layout of `Package`'s and you forget the version used to serialize the results, you can use the same `load` function *without* calling `registertype!` in the Julia session in order to deserialize the results back as `NamedTuple`'s (instead of as `Package`s), providing some amount of robustness.

--- a/src/PackageAnalyzer.jl
+++ b/src/PackageAnalyzer.jl
@@ -1,4 +1,4 @@
-module AnalyzeRegistry
+module PackageAnalyzer
 
 # Standard libraries
 using Pkg, TOML, UUIDs
@@ -217,7 +217,7 @@ end
 
 
 """
-    AnalyzeRegistry.github_auth(token::String="")
+    PackageAnalyzer.github_auth(token::String="")
 
 Obtain a GitHub authetication.  Use the `token` argument if it is non-empty,
 otherwise use the `GITHUB_TOKEN` and `GITHUB_AUTH` environment variables, if set
@@ -246,7 +246,7 @@ of the package, if such a directory does not already exist.
 If the GitHub authentication is non-anonymous and the repository is on GitHub,
 the list of contributors to the repository is also collected.  Only the number
 of contributors will be shown in the summary.  See
-[`AnalyzeRegistry.github_auth`](@ref) to obtain a GitHub authentication.
+[`PackageAnalyzer.github_auth`](@ref) to obtain a GitHub authentication.
 """
 function analyze!(root, pkg::RegistryEntry; auth::GitHub.Authorization=github_auth())
     # Parse the `Package.toml` file in the given directory.
@@ -301,7 +301,7 @@ if a directory with their `uuid` does not already exist.  Returns a
 
 If the GitHub authentication is non-anonymous and the repository is on GitHub,
 the list of contributors to the repositories is also collected.  See
-[`AnalyzeRegistry.github_auth`](@ref) to obtain a GitHub authentication.
+[`PackageAnalyzer.github_auth`](@ref) to obtain a GitHub authentication.
 
 """
 function analyze!(root, registry_entries::AbstractVector{RegistryEntry}; auth::GitHub.Authorization=github_auth())
@@ -329,7 +329,7 @@ cleaning up the temporary directory afterwards.
 If the GitHub authentication is non-anonymous and the repository is on GitHub,
 the list of contributors to the repository is also collected.  Only the number
 of contributors will be shown in the summary.  See
-[`AnalyzeRegistry.github_auth`](@ref) to obtain a GitHub authentication.
+[`PackageAnalyzer.github_auth`](@ref) to obtain a GitHub authentication.
 
 ## Example
 ```julia
@@ -399,7 +399,7 @@ and analyzed.
 If the GitHub authentication is non-anonymous and the repository is on GitHub,
 the list of contributors to the repository is also collected.  Only the number
 of contributors will be shown in the summary.  See
-[`AnalyzeRegistry.github_auth`](@ref) to obtain a GitHub authentication.
+[`PackageAnalyzer.github_auth`](@ref) to obtain a GitHub authentication.
 
 ## Example
 

--- a/test/baduuid/Project.toml
+++ b/test/baduuid/Project.toml
@@ -1,2 +1,2 @@
-name = "AnalyzeRegistry"
+name = "PackageAnalyzer"
 uuid = "hello"

--- a/test/license_in_project/Project.toml
+++ b/test/license_in_project/Project.toml
@@ -1,3 +1,3 @@
-name = "AnalyzeRegistry"
+name = "PackageAnalyzer"
 uuid = "e713c705-17e4-4cec-abe0-95bf5bf3e10c"
 license = "MIT"

--- a/test/licenses_in_project/JuliaProject.toml
+++ b/test/licenses_in_project/JuliaProject.toml
@@ -1,3 +1,3 @@
-name = "AnalyzeRegistry"
+name = "PackageAnalyzer"
 uuid = "e713c705-17e4-4cec-abe0-95bf5bf3e10c"
 license = ["MIT", "GPL"]

--- a/test/missingquote/Project.toml
+++ b/test/missingquote/Project.toml
@@ -1,2 +1,2 @@
-name = "AnalyzeRegistry"
+name = "PackageAnalyzer"
 uuid = "e713c705-17e4-4cec-abe0-95bf5bf3e10c


### PR DESCRIPTION
I'm undecided between AnalyzePackage (singular) and AnalyzePackages (plural).
Thoughts?

Fix #20.